### PR TITLE
Return names in metaedge_to_adjacency_matrix

### DIFF
--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -48,7 +48,7 @@ def dwwc(graph, metapath, damping=0.5):
     """
     dwwc_matrix = None
     for metaedge in metapath:
-        adj_mat = metaedge_to_adjacency_matrix(graph, metaedge)
+        rows, cols, adj_mat = metaedge_to_adjacency_matrix(graph, metaedge)
         adj_mat = dwwc_step(adj_mat, damping, damping)
         if dwwc_matrix is None:
             dwwc_matrix = adj_mat

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -87,7 +87,8 @@ def diffuse(
         node_scores[i] = weight
 
     for metaedge in metapath:
-        adjacency_matrix = metaedge_to_adjacency_matrix(graph, metaedge)
+        row_names, column_names, adjacency_matrix = (
+            metaedge_to_adjacency_matrix(graph, metaedge))
 
         # Row/column normalization with degree damping
         adjacency_matrix = diffusion_step(
@@ -95,7 +96,5 @@ def diffuse(
 
         node_scores = node_scores @ adjacency_matrix
 
-    target_metanode = metapath.target()
-    target_node_to_position = get_node_to_position(graph, target_metanode)
-    node_to_score = OrderedDict(zip(target_node_to_position, node_scores))
+    node_to_score = OrderedDict(zip(column_names, node_scores))
     return node_to_score

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -34,7 +34,9 @@ def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_):
         for edge in source_node.edges[metaedge]:
             j = target_node_to_position[edge.target]
             adjacency_matrix[i, j] = 1
-    return adjacency_matrix
+    row_names = [node.identifier for node in source_nodes]
+    column_names = [node.identifier for node in target_node_to_position]
+    return row_names, column_names, adjacency_matrix
 
 
 def normalize(matrix, vector, axis, damping_exponent):

--- a/hetmech/xarray.py
+++ b/hetmech/xarray.py
@@ -1,8 +1,7 @@
 import numpy
 import xarray
-import hetio.hetnet
 
-from .diffusion import get_node_to_position
+from .matrix import metaedge_to_adjacency_matrix
 
 
 def graph_to_xarray(graph):
@@ -23,24 +22,11 @@ def metaedge_to_data_array(graph, metaedge, dtype=numpy.bool_):
     Return an xarray.DataArray that's an adjacency matrix where source nodes
     are columns and target nodes are rows.
     """
-    if not isinstance(metaedge, hetio.hetnet.MetaEdge):
-        # metaedge is an abbreviation
-        metaedge = graph.metagraph.metapath_from_abbrev(metaedge)[0]
-
-    source_nodes = list(get_node_to_position(graph, metaedge.source))
-    target_node_to_position = get_node_to_position(graph, metaedge.target)
-    shape = len(source_nodes), len(target_node_to_position)
-    adjacency_matrix = numpy.zeros(shape, dtype=dtype)
-    for i, source_node in enumerate(source_nodes):
-        for edge in source_node.edges[metaedge]:
-            j = target_node_to_position[edge.target]
-            adjacency_matrix[i, j] = 1
+    source_node_ids, target_node_ids, adjacency_matrix = (
+        metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_))
 
     dims = metaedge.source.identifier, metaedge.target.identifier
-    coords = (
-        [node.identifier for node in source_nodes],
-        [node.identifier for node in target_node_to_position],
-    )
+    coords = source_node_ids, target_node_ids
 
     data_array = xarray.DataArray(
         adjacency_matrix,


### PR DESCRIPTION
`metaedge_to_adjacency_matrix` now returns row and column names. Avoids having to recompute order later. Adjacency matrixes are meaningless without the identity of their nodes, so this info should get returned at creation time. Paves the way for #12 