### PR TITLE
Add sparse functionality in degree_weight and diffusion

### DIFF
--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -9,7 +9,7 @@ from scipy import sparse
 from .matrix import (normalize,
                      metaedge_to_adjacency_matrix,
                      auto_convert,
-                     new_array)
+                     copy_array)
 
 
 def dwwc_step(matrix, row_damping=0, column_damping=0, copy=True):
@@ -39,7 +39,7 @@ def dwwc_step(matrix, row_damping=0, column_damping=0, copy=True):
         Normalized matrix with dtype.float64.
     """
     # returns a newly allocated array
-    matrix = new_array(matrix, copy)
+    matrix = copy_array(matrix, copy)
 
     row_sums = numpy.array(matrix.sum(axis=1)).flatten()
     column_sums = numpy.array(matrix.sum(axis=0)).flatten()
@@ -130,7 +130,7 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
     metapath : hetio.hetnet.MetaPath
     duplicate : hetio.hetnet.MetaNode or None
     damping : float
-    sparse_threshold : float (0 < sparse_threshold < 1)
+    sparse_threshold : float (0 <= sparse_threshold <= 1)
         sets the density threshold above which a sparse matrix will be
         converted to a dense automatically.
     """
@@ -139,9 +139,8 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
     dwpc_matrix = None
     row_names = None
     for metaedge in metapath:
-        rows, cols, adj_mat = \
-            metaedge_to_adjacency_matrix(graph, metaedge,
-                                         sparse_threshold=sparse_threshold)
+        rows, cols, adj_mat = metaedge_to_adjacency_matrix(
+            graph, metaedge, sparse_threshold=sparse_threshold)
         adj_mat = dwwc_step(adj_mat, damping, damping)
         if dwpc_matrix is None:
             row_names = rows
@@ -155,7 +154,7 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
                 mat_type = numpy.array
             diag_matrix = sparse.diags(dwpc_matrix.diagonal())
             dwpc_matrix = mat_type(dwpc_matrix - diag_matrix,
-                                   dtype=numpy.float64)
+                                   dtype=numpy.float64, copy=False)
 
     dwpc_matrix = auto_convert(dwpc_matrix, sparse_threshold)
     return row_names, cols, dwpc_matrix

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -147,7 +147,8 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
                 mat_type = numpy.array
 
             diag_matrix = sparse.diags(dwpc_matrix.diagonal())
-            dwpc_matrix = mat_type(dwpc_matrix - diag_matrix)
+            dwpc_matrix = mat_type(dwpc_matrix - diag_matrix,
+                                   dtype=numpy.float64)
     return row_names, cols, dwpc_matrix
 
 

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -152,7 +152,7 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
     return row_names, cols, dwpc_matrix
 
 
-def dwpc(graph, metapath, damping=0.5):
+def dwpc(graph, metapath, damping=0.5, auto=False):
     """
     Compute the degree-weighted path count (DWPC).
     """
@@ -165,10 +165,10 @@ def dwpc(graph, metapath, damping=0.5):
     row_names = None
     for segment, duplicate in zip(segments, duplicates):
         if duplicate is None:
-            rows, cols, matrix = dwwc(graph, segment, damping)
+            rows, cols, matrix = dwwc(graph, segment, damping, auto=auto)
         else:
             rows, cols, matrix = dwpc_duplicated_metanode(
-                graph, segment, duplicate, damping)
+                graph, segment, duplicate, damping, auto=auto)
         if row_names is None:
             row_names = rows
         parts.append(matrix)

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -142,11 +142,8 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
                 if dwpc_matrix.nnz > (1/3) * numpy.prod(dwpc_matrix.shape):
                     dwpc_matrix = dwpc_matrix.toarray()
         if metaedge.target == duplicate:
-            if sparse.issparse(dwpc_matrix):
-                diag_matrix = sparse.diags(dwpc_matrix.diagonal())
-            else:
-                diag_matrix = numpy.diag(dwpc_matrix.diagonal())
-            dwpc_matrix -= diag_matrix
+            diag_matrix = sparse.diags(dwpc_matrix.diagonal())
+            dwpc_matrix = numpy.array(dwpc_matrix - diag_matrix)
     return row_names, cols, dwpc_matrix
 
 

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -142,8 +142,12 @@ def dwpc_duplicated_metanode(graph, metapath, duplicate=None, damping=0.5,
                 if dwpc_matrix.nnz > (1/3) * numpy.prod(dwpc_matrix.shape):
                     dwpc_matrix = dwpc_matrix.toarray()
         if metaedge.target == duplicate:
+            mat_type = type(dwpc_matrix)
+            if mat_type == numpy.ndarray:
+                mat_type = numpy.array
+
             diag_matrix = sparse.diags(dwpc_matrix.diagonal())
-            dwpc_matrix = numpy.array(dwpc_matrix - diag_matrix)
+            dwpc_matrix = mat_type(dwpc_matrix - diag_matrix)
     return row_names, cols, dwpc_matrix
 
 

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -4,7 +4,8 @@ import numpy
 
 from .matrix import (normalize,
                      get_node_to_position,
-                     metaedge_to_adjacency_matrix)
+                     metaedge_to_adjacency_matrix,
+                     new_array)
 
 
 def diffusion_step(
@@ -38,11 +39,7 @@ def diffusion_step(
         Normalized matrix with dtype.float64.
     """
     # returns a newly allocated array
-    mat_type = type(matrix)
-    if mat_type == numpy.ndarray:
-        mat_type = numpy.array
-    matrix = mat_type(matrix, dtype=numpy.float64, copy=copy)
-    assert matrix.ndim == 2
+    matrix = new_array(matrix, copy=copy)
 
     # Perform column normalization
     if column_damping != 0:

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -59,8 +59,7 @@ def diffuse(
         metapath,
         source_node_weights,
         column_damping=0,
-        row_damping=1,
-        mat_type=numpy.ndarray
+        row_damping=1
         ):
     """
     Performs diffusion from the specified source nodes.
@@ -77,8 +76,6 @@ def diffuse(
         exponent of (out)degree in column normalization
     row_damping : scalar
         exponent of (in)degree in row normalization
-    mat_type : type
-        type of adjacency matrix to be made. scipy.sparse or numpy.ndarray
     """
 
     # Initialize node weights
@@ -91,8 +88,7 @@ def diffuse(
 
     for metaedge in metapath:
         row_names, column_names, adjacency_matrix = (
-            metaedge_to_adjacency_matrix(graph, metaedge,
-                                         matrix_type=mat_type))
+            metaedge_to_adjacency_matrix(graph, metaedge))
 
         # Row/column normalization with degree damping
         adjacency_matrix = diffusion_step(

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -5,7 +5,7 @@ import numpy
 from .matrix import (normalize,
                      get_node_to_position,
                      metaedge_to_adjacency_matrix,
-                     new_array)
+                     copy_array)
 
 
 def diffusion_step(
@@ -39,7 +39,7 @@ def diffusion_step(
         Normalized matrix with dtype.float64.
     """
     # returns a newly allocated array
-    matrix = new_array(matrix, copy=copy)
+    matrix = copy_array(matrix, copy=copy)
 
     # Perform column normalization
     if column_damping != 0:

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -81,7 +81,7 @@ def diffuse(
     row_damping : scalar
         exponent of (in)degree in row normalization
     mat_type : type
-        type of adjacency matrix to be produced
+        type of adjacency matrix to be made. scipy.sparse or numpy.ndarray
     """
 
     # Initialize node weights

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -50,7 +50,6 @@ def metaedge_to_adjacency_matrix(
     adjacency_matrix = sparse.csc_matrix((data, (row, col)), shape=shape,
                                          dtype=dtype)
     adjacency_matrix = auto_convert(adjacency_matrix, sparse_threshold)
-
     row_names = [node.identifier for node in source_nodes]
     column_names = [node.identifier for node in target_node_to_position]
     return row_names, column_names, adjacency_matrix

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -101,14 +101,14 @@ def auto_convert(matrix, threshold):
     """
     above_thresh = (matrix != 0).sum() / numpy.prod(matrix.shape) >= threshold
     if sparse.issparse(matrix) and above_thresh:
-        matrix = matrix.toarray()
-    elif not sparse.issparse(matrix) and not above_thresh:
-        matrix = sparse.csc_matrix(matrix)
+        return matrix.toarray()
+    elif not above_thresh:
+        return sparse.csc_matrix(matrix)
     return matrix
 
 
-def new_array(matrix, copy=True):
-    """Returns a newly allocated array"""
+def copy_array(matrix, copy=True):
+    """Returns a newly allocated array if copy is True"""
     mat_type = type(matrix)
     if mat_type == numpy.ndarray:
         mat_type = numpy.array

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -18,8 +18,8 @@ def get_node_to_position(graph, metanode):
     return node_to_position
 
 
-def metaedge_to_adjacency_matrix(
-        graph, metaedge, dtype=numpy.bool_, sparse_threshold=0):
+def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_,
+                                 sparse_threshold=0):
     """
     Returns an adjacency matrix where source nodes are rows and target
     nodes are columns.
@@ -31,10 +31,8 @@ def metaedge_to_adjacency_matrix(
     dtype : type
     sparse_threshold : float (0 < sparse_threshold < 1)
         sets the density threshold above which a sparse matrix will be
-        converted to a dense automatically. Supersedes mat_type if the
-        density is below the threshold.
+        converted to a dense automatically.
     """
-
     if not isinstance(metaedge, hetio.hetnet.MetaEdge):
         # metaedge is an abbreviation
         metaedge = graph.metagraph.metapath_from_abbrev(metaedge)[0]

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -19,8 +19,7 @@ def get_node_to_position(graph, metanode):
 
 
 def metaedge_to_adjacency_matrix(
-        graph, metaedge, dtype=numpy.bool_, sparse_threshold=0,
-        matrix_type=numpy.ndarray):
+        graph, metaedge, dtype=numpy.bool_, sparse_threshold=0):
     """
     Returns an adjacency matrix where source nodes are rows and target
     nodes are columns.
@@ -34,9 +33,6 @@ def metaedge_to_adjacency_matrix(
         sets the density threshold above which a sparse matrix will be
         converted to a dense automatically. Supersedes mat_type if the
         density is below the threshold.
-    matrix_type : type or None
-        type of matrix to be used. Only relevant above the
-        sparse_threshold.
     """
 
     if not isinstance(metaedge, hetio.hetnet.MetaEdge):
@@ -53,8 +49,7 @@ def metaedge_to_adjacency_matrix(
             data.append(1)
     adjacency_matrix = sparse.csc_matrix((data, (row, col)), shape=shape,
                                          dtype=dtype)
-    adjacency_matrix = auto_convert(adjacency_matrix, sparse_threshold,
-                                    matrix_type=matrix_type)
+    adjacency_matrix = auto_convert(adjacency_matrix, sparse_threshold)
 
     row_names = [node.identifier for node in source_nodes]
     column_names = [node.identifier for node in target_node_to_position]
@@ -91,7 +86,7 @@ def normalize(matrix, vector, axis, damping_exponent):
     return matrix
 
 
-def auto_convert(matrix, threshold, matrix_type=numpy.ndarray):
+def auto_convert(matrix, threshold):
     """
     Automatically convert a scipy.sparse to a numpy.ndarray if the percent
     nonzero is above a given threshold. Automatically convert a numpy.ndarray
@@ -102,8 +97,6 @@ def auto_convert(matrix, threshold, matrix_type=numpy.ndarray):
     matrix : numpy.ndarray or scipy.sparse
     threshold : float (0 < threshold < 1)
         percent nonzero above which the matrix is converted to dense
-    matrix_type : type or None
-        if density is above threshold, convert to this type
 
     Returns
     =======
@@ -112,9 +105,6 @@ def auto_convert(matrix, threshold, matrix_type=numpy.ndarray):
     if sparse.issparse(matrix):
         if (matrix != 0).sum() / numpy.prod(matrix.shape) >= threshold:
             matrix = matrix.toarray()
-            if matrix_type == numpy.ndarray or not matrix_type:
-                matrix_type = numpy.array
-            matrix = matrix_type(matrix)
     elif not sparse.issparse(matrix):
         if (matrix != 0).sum() / numpy.prod(matrix.shape) < threshold:
             matrix = sparse.csc_matrix(matrix)

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -102,12 +102,11 @@ def auto_convert(matrix, threshold):
     =======
     matrix : numpy.ndarray or scipy.sparse
     """
-    if sparse.issparse(matrix):
-        if (matrix != 0).sum() / numpy.prod(matrix.shape) >= threshold:
-            matrix = matrix.toarray()
-    elif not sparse.issparse(matrix):
-        if (matrix != 0).sum() / numpy.prod(matrix.shape) < threshold:
-            matrix = sparse.csc_matrix(matrix)
+    above_thresh = (matrix != 0).sum() / numpy.prod(matrix.shape) >= threshold
+    if sparse.issparse(matrix) and above_thresh:
+        matrix = matrix.toarray()
+    elif not sparse.issparse(matrix) and not above_thresh:
+        matrix = sparse.csc_matrix(matrix)
     return matrix
 
 

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -108,15 +108,12 @@ def get_expect(m_path, threshold):
     return type_dwwc, dwwc_mat, type_dwpc, dwpc_mat, row_names, col_names
 
 
-@pytest.mark.parametrize('thresh', (0, 0.2, 0.3, 0.5, 0.7, 0.9, 1))
+@pytest.mark.parametrize('thresh', (0, 0.25, 0.3, 0.5, 0.7, 1))
 @pytest.mark.parametrize('m_path', ('GiGaD', 'GaDaG', 'GeTlD', 'GiG'))
 def test_dwpc_duplicated_metanode(m_path, thresh):
     """
     Test the ability of dwpc_duplicated_metanode to convert dwpc_matrix to a
-    dense array when the percent nonzero goes above the 1/3 threshold. If auto
-    is off, the matrices will start and stay sparse or dense throughout.
-    If auto is on, the matrices start sparse and will be converted to dense
-    arrays when their densities exceeds 1/3.
+    dense array when the percent nonzero goes above the threshold.
     Checks output of dwpc_duplicated_metanode.
     """
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -1,9 +1,9 @@
 import hetio.readwrite
+import numpy
 import pytest
 from scipy import sparse
-import numpy
 
-from .degree_weight import dwwc
+from .degree_weight import dwwc, dwpc_duplicated_metanode
 
 
 def test_disease_gene_example_dwwc():
@@ -36,34 +36,106 @@ def test_disease_gene_example_dwwc():
     # contains duplicate metanodes, WC and PC are not guaranteed to be the
     # same. However, they happen to be equivalent for this example.
     assert wc_matrix[i, j] == 3
-    assert dwwc_matrix[i, j] == pytest.approx(0.25 + 0.25 + 32**-0.5)
+    assert dwwc_matrix[i, j] == pytest.approx(0.25 + 0.25 + 32 ** -0.5)
+
+
+def get_expect(m_path, auto):
+    if m_path in ('GiGaD', 'GaDaG') and auto:
+        mattype = 'dense'
+    else:  # Others never reach threshold density
+        mattype = 'sparse'
+    mat_dict = {
+        'GiGaD': [[0.25, 0.],
+                  [0.35355339, 0.],
+                  [0., 0.6767767],
+                  [0.35355339, 0.],
+                  [0., 0.35355339],
+                  [0., 0.],
+                  [0.35355339, 0.]],
+        'GaDaG': [[0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                  [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                  [0., 0., 0.5, 0., 0., 0.35355339, 0.],
+                  [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                  [0., 0., 0., 0., 0., 0., 0.],
+                  [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0., 0.375, 0.],
+                  [0., 0., 0., 0., 0., 0., 0.]],
+        'GeTlD': [[0., 0.],
+                  [0., 0.],
+                  [0., 0.70710678],
+                  [0., 0.],
+                  [0., 0.],
+                  [0., 0.],
+                  [0., 0.]],
+        'GiG': [[0., 0., 0.35355339, 0., 0.70710678, 0., 0.],
+                [0., 0., 0.5, 0., 0., 0., 0.],
+                [0.35355339, 0.5, 0., 0.5, 0., 0., 0.5],
+                [0., 0., 0.5, 0., 0., 0., 0.],
+                [0.70710678, 0., 0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0., 0., 0.],
+                [0., 0., 0.5, 0., 0., 0., 0.]],
+        'GaDaG_dwpc': [[0., 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                       [0.25, 0., 0., 0.25, 0., 0.1767767, 0.],
+                       [0., 0., 0., 0., 0., 0.35355339, 0.],
+                       [0.25, 0.25, 0., 0., 0., 0.1767767, 0.],
+                       [0., 0., 0., 0., 0., 0., 0.],
+                       [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0.,
+                        0., 0.],
+                       [0., 0., 0., 0., 0., 0., 0.]]
+    }
+    node_dict = {
+        'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
+        'D': ["Crohn's Disease", 'Multiple Sclerosis'],
+        'T': ['Leukocyte', 'Lung']
+    }
+    if m_path == 'GaDaG':
+        dwwc_mat = numpy.array(mat_dict[m_path])
+        dwpc_mat = numpy.array(mat_dict['GaDaG_dwpc'])
+    else:
+        dwwc_mat = dwpc_mat = numpy.array(mat_dict[m_path])
+    row_names = node_dict[m_path[0]]
+    col_names = node_dict[m_path[-1]]
+    return mattype, dwwc_mat, dwpc_mat, row_names, col_names
 
 
 @pytest.mark.parametrize('auto', [True, False])
-def test_dwwc_auto(auto):
+@pytest.mark.parametrize('m_path', ('GiGaD', 'GaDaG', 'GeTlD', 'GiG'))
+def test_dwpc_duplicated_metanode(m_path, auto):
     """
-    Test the ability of dwwc to convert dwwc_matrix to a dense array when
-    the percent nonzero goes above the 1/3 threshold. If auto is off, the
-    matrices will start as sparse and stay sparse throughout. If auto is on,
-    the matrices start sparse and will be converted to dense arrays when their
-    density exceeds 1/3.
+    Test the ability of dwwc to convert dwwc_matrix to a dense array when the
+    percent nonzero goes above the 1/3 threshold. If auto is off, the matrices
+    will start as sparse and stay sparse throughout. If auto is on, the
+    matrices start sparse and will be converted to dense arrays when their
+    densities exceeds 1/3.
+    Also tests the matrix output in generating degree-weighted paths.
     """
+
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
         '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
         'test/data/disease-gene-example-graph.json',
     )
     graph = hetio.readwrite.read_graph(url)
     metagraph = graph.metagraph
-    metapath = metagraph.metapath_from_abbrev('GiGaD')
+    metapath = metagraph.metapath_from_abbrev(m_path)
+    dup = metapath.get_nodes()[0]
+    rows, cols, dwwc_mat = dwpc_duplicated_metanode(
+        graph, metapath, damping=0.5, auto=auto, mat_type=sparse.csc_matrix,
+        duplicate=None)
+    rows, cols, dwpc_mat = dwpc_duplicated_metanode(
+        graph, metapath, damping=0.5, auto=auto, mat_type=sparse.csc_matrix,
+        duplicate=dup)
 
-    rows, cols, pc_matrix = dwwc(graph, metapath, damping=0, auto=auto,
-                                 mat_type=sparse.csc_matrix)
-    rows, cols, dwwc_matrix = dwwc(graph, metapath, damping=0.5, auto=auto,
-                                   mat_type=sparse.csc_matrix)
+    exp_type, exp_dwwc, exp_dwpc, exp_row, exp_col = get_expect(m_path, auto)
 
-    if auto:
-        assert isinstance(dwwc_matrix, numpy.ndarray)
-        assert isinstance(pc_matrix, numpy.ndarray)
+    # Test AUTO mode
+    if exp_type == 'dense':
+        assert isinstance(dwwc_mat, numpy.ndarray)
+        assert isinstance(dwpc_mat, numpy.ndarray)
     else:
-        assert sparse.issparse(dwwc_matrix)
-        assert sparse.issparse(pc_matrix)
+        assert sparse.issparse(dwwc_mat)
+        assert sparse.issparse(dwpc_mat)
+
+    # Test row and column label output
+    assert (dwwc_mat - exp_dwwc).sum() < 0.00001  # Assert equal
+    assert (dwpc_mat - exp_dwpc).sum() < 0.00001  # Assert equal
+    assert rows == exp_row
+    assert cols == exp_col

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -40,6 +40,7 @@ def test_disease_gene_example_dwwc():
 
 
 def get_expect(m_path, threshold):
+    # Dictionary with tuples of matrix and percent nonzero
     mat_dict = {
         'GiGaD': ([[0.25, 0.],
                    [0.35355339, 0.],
@@ -88,7 +89,6 @@ def get_expect(m_path, threshold):
         True: numpy.array,
         False: sparse.csc_matrix
     }
-
     row_names = node_dict[m_path[0]]
     col_names = node_dict[m_path[-1]]
 

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -101,12 +101,12 @@ def get_expect(m_path, auto):
 @pytest.mark.parametrize('m_path', ('GiGaD', 'GaDaG', 'GeTlD', 'GiG'))
 def test_dwpc_duplicated_metanode(m_path, auto):
     """
-    Test the ability of dwwc to convert dwwc_matrix to a dense array when the
-    percent nonzero goes above the 1/3 threshold. If auto is off, the matrices
-    will start as sparse and stay sparse throughout. If auto is on, the
-    matrices start sparse and will be converted to dense arrays when their
-    densities exceeds 1/3.
-    Also tests the matrix output in generating degree-weighted paths.
+    Test the ability of dwpc_duplicated_metanode to convert dwpc_matrix to a
+    dense array when the percent nonzero goes above the 1/3 threshold. If auto
+    is off, the matrices will start and stay sparse or dense throughout.
+    If auto is on, the matrices start sparse and will be converted to dense
+    arrays when their densities exceeds 1/3.
+   Checks output of dwpc_duplicated_metanode.
     """
 
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
@@ -134,7 +134,7 @@ def test_dwpc_duplicated_metanode(m_path, auto):
         assert sparse.issparse(dwwc_mat)
         assert sparse.issparse(dwpc_mat)
 
-    # Test row and column label output
+    # Test matrix, row, and column label output
     assert (dwwc_mat - exp_dwwc).sum() < 0.00001  # Assert equal
     assert (dwpc_mat - exp_dwpc).sum() < 0.00001  # Assert equal
     assert rows == exp_row

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -117,7 +117,7 @@ def test_dwpc_duplicated_metanode(m_path, thresh):
     is off, the matrices will start and stay sparse or dense throughout.
     If auto is on, the matrices start sparse and will be converted to dense
     arrays when their densities exceeds 1/3.
-   Checks output of dwpc_duplicated_metanode.
+    Checks output of dwpc_duplicated_metanode.
     """
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
         '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -39,7 +39,7 @@ def test_disease_gene_example_dwwc():
     assert dwwc_matrix[i, j] == pytest.approx(0.25 + 0.25 + 32 ** -0.5)
 
 
-def get_expect(m_path, threshold, mattype):
+def get_expect(m_path, threshold):
     mat_dict = {
         'GiGaD': ([[0.25, 0.],
                    [0.35355339, 0.],
@@ -85,7 +85,7 @@ def get_expect(m_path, threshold, mattype):
         'T': ['Leukocyte', 'Lung']
     }
     type_dict = {
-        True: mattype if mattype else numpy.array,
+        True: numpy.array,
         False: sparse.csc_matrix
     }
 
@@ -108,10 +108,9 @@ def get_expect(m_path, threshold, mattype):
     return type_dwwc, dwwc_mat, type_dwpc, dwpc_mat, row_names, col_names
 
 
-@pytest.mark.parametrize('mattype', [sparse.csc_matrix])
 @pytest.mark.parametrize('thresh', (0, 0.2, 0.3, 0.5, 0.7, 0.9, 1))
 @pytest.mark.parametrize('m_path', ('GiGaD', 'GaDaG', 'GeTlD', 'GiG'))
-def test_dwpc_duplicated_metanode(m_path, thresh, mattype):
+def test_dwpc_duplicated_metanode(m_path, thresh):
     """
     Test the ability of dwpc_duplicated_metanode to convert dwpc_matrix to a
     dense array when the percent nonzero goes above the 1/3 threshold. If auto
@@ -129,14 +128,12 @@ def test_dwpc_duplicated_metanode(m_path, thresh, mattype):
     metapath = metagraph.metapath_from_abbrev(m_path)
     dup = metapath.get_nodes()[0]
     rows, cols, dwwc_mat = dwpc_duplicated_metanode(
-        graph, metapath, damping=0.5, mat_type=mattype,
-        duplicate=None, sparse_threshold=thresh)
+        graph, metapath, damping=0.5, duplicate=None, sparse_threshold=thresh)
     rows, cols, dwpc_mat = dwpc_duplicated_metanode(
-        graph, metapath, damping=0.5, mat_type=mattype,
-        duplicate=dup, sparse_threshold=thresh)
+        graph, metapath, damping=0.5, duplicate=dup, sparse_threshold=thresh)
 
     exp_type_dwwc, exp_dwwc, exp_type_dwpc, exp_dwpc, exp_row, exp_col = \
-        get_expect(m_path, thresh, mattype)
+        get_expect(m_path, thresh)
 
     if exp_type_dwwc == numpy.array:
         assert isinstance(dwwc_mat, numpy.ndarray)

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -39,7 +39,7 @@ def test_disease_gene_example_dwwc():
     assert dwwc_matrix[i, j] == pytest.approx(0.25 + 0.25 + 32 ** -0.5)
 
 
-def get_expect(m_path, threshold):
+def get_expected(metapath, threshold):
     # Dictionary with tuples of matrix and percent nonzero
     mat_dict = {
         'GiGaD': ([[0.25, 0.],
@@ -89,18 +89,18 @@ def get_expect(m_path, threshold):
         True: numpy.array,
         False: sparse.csc_matrix
     }
-    row_names = node_dict[m_path[0]]
-    col_names = node_dict[m_path[-1]]
+    row_names = node_dict[metapath[0]]
+    col_names = node_dict[metapath[-1]]
 
-    if m_path == 'GaDaG':
+    if metapath == 'GaDaG':
         dwwc_mat = mat_dict['GaDaG'][0]
         dwpc_mat = mat_dict['GaDaG_dwpc'][0]
         type_dwwc = type_dict[mat_dict['GaDaG'][1] >= threshold]
         type_dwpc = type_dict[mat_dict['GaDaG_dwpc'][1] >= threshold]
     else:
-        dwwc_mat = dwpc_mat = mat_dict[m_path][0]
-        type_dwwc = type_dict[mat_dict[m_path][1] >= threshold]
-        type_dwpc = type_dict[mat_dict[m_path][1] >= threshold]
+        dwwc_mat = dwpc_mat = mat_dict[metapath][0]
+        type_dwwc = type_dict[mat_dict[metapath][1] >= threshold]
+        type_dwpc = type_dict[mat_dict[metapath][1] >= threshold]
 
     dwwc_mat = type_dwwc(dwwc_mat)
     dwpc_mat = type_dwpc(dwpc_mat)
@@ -130,7 +130,7 @@ def test_dwpc_duplicated_metanode(m_path, thresh):
         graph, metapath, damping=0.5, duplicate=dup, sparse_threshold=thresh)
 
     exp_type_dwwc, exp_dwwc, exp_type_dwpc, exp_dwpc, exp_row, exp_col = \
-        get_expect(m_path, thresh)
+        get_expected(m_path, thresh)
 
     if exp_type_dwwc == numpy.array:
         assert isinstance(dwwc_mat, numpy.ndarray)
@@ -143,7 +143,7 @@ def test_dwpc_duplicated_metanode(m_path, thresh):
         assert sparse.issparse(dwpc_mat)
 
     # Test matrix, row, and column label output
-    assert (dwwc_mat - exp_dwwc).sum() < 0.000001  # Assert approx equal
-    assert (dwpc_mat - exp_dwpc).sum() < 0.000001  # Assert approx equal
+    assert pytest.approx((dwwc_mat - exp_dwwc).sum(), 0)  # Assert approx equal
+    assert pytest.approx((dwpc_mat - exp_dwpc).sum(), 0)  # Assert approx equal
     assert rows == exp_row
     assert cols == exp_col

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -39,67 +39,79 @@ def test_disease_gene_example_dwwc():
     assert dwwc_matrix[i, j] == pytest.approx(0.25 + 0.25 + 32 ** -0.5)
 
 
-def get_expect(m_path, auto):
-    if m_path in ('GiGaD', 'GaDaG') and auto:
-        mattype = 'dense'
-    else:  # Others never reach threshold density
-        mattype = 'sparse'
+def get_expect(m_path, threshold, mattype):
     mat_dict = {
-        'GiGaD': [[0.25, 0.],
-                  [0.35355339, 0.],
-                  [0., 0.6767767],
-                  [0.35355339, 0.],
-                  [0., 0.35355339],
-                  [0., 0.],
-                  [0.35355339, 0.]],
-        'GaDaG': [[0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
-                  [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
-                  [0., 0., 0.5, 0., 0., 0.35355339, 0.],
-                  [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
-                  [0., 0., 0., 0., 0., 0., 0.],
-                  [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0., 0.375, 0.],
-                  [0., 0., 0., 0., 0., 0., 0.]],
-        'GeTlD': [[0., 0.],
-                  [0., 0.],
-                  [0., 0.70710678],
-                  [0., 0.],
-                  [0., 0.],
-                  [0., 0.],
-                  [0., 0.]],
-        'GiG': [[0., 0., 0.35355339, 0., 0.70710678, 0., 0.],
-                [0., 0., 0.5, 0., 0., 0., 0.],
-                [0.35355339, 0.5, 0., 0.5, 0., 0., 0.5],
-                [0., 0., 0.5, 0., 0., 0., 0.],
-                [0.70710678, 0., 0., 0., 0., 0., 0.],
-                [0., 0., 0., 0., 0., 0., 0.],
-                [0., 0., 0.5, 0., 0., 0., 0.]],
-        'GaDaG_dwpc': [[0., 0.25, 0., 0.25, 0., 0.1767767, 0.],
-                       [0.25, 0., 0., 0.25, 0., 0.1767767, 0.],
-                       [0., 0., 0., 0., 0., 0.35355339, 0.],
-                       [0.25, 0.25, 0., 0., 0., 0.1767767, 0.],
-                       [0., 0., 0., 0., 0., 0., 0.],
-                       [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0.,
-                        0., 0.],
-                       [0., 0., 0., 0., 0., 0., 0.]]
+        'GiGaD': ([[0.25, 0.],
+                   [0.35355339, 0.],
+                   [0., 0.6767767],
+                   [0.35355339, 0.],
+                   [0., 0.35355339],
+                   [0., 0.],
+                   [0.35355339, 0.]], 0.429),
+        'GaDaG': ([[0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                   [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                   [0., 0., 0.5, 0., 0., 0.35355339, 0.],
+                   [0.25, 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                   [0., 0., 0., 0., 0., 0., 0.],
+                   [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0., 0.375,
+                    0.],
+                   [0., 0., 0., 0., 0., 0., 0.]], 0.388),
+        'GeTlD': ([[0., 0.],
+                   [0., 0.],
+                   [0., 0.70710678],
+                   [0., 0.],
+                   [0., 0.],
+                   [0., 0.],
+                   [0., 0.]], 0.071),
+        'GiG': ([[0., 0., 0.35355339, 0., 0.70710678, 0., 0.],
+                 [0., 0., 0.5, 0., 0., 0., 0.],
+                 [0.35355339, 0.5, 0., 0.5, 0., 0., 0.5],
+                 [0., 0., 0.5, 0., 0., 0., 0.],
+                 [0.70710678, 0., 0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0., 0., 0.],
+                 [0., 0., 0.5, 0., 0., 0., 0.]], 0.204),
+        'GaDaG_dwpc': ([[0., 0.25, 0., 0.25, 0., 0.1767767, 0.],
+                        [0.25, 0., 0., 0.25, 0., 0.1767767, 0.],
+                        [0., 0., 0., 0., 0., 0.35355339, 0.],
+                        [0.25, 0.25, 0., 0., 0., 0.1767767, 0.],
+                        [0., 0., 0., 0., 0., 0., 0.],
+                        [0.1767767, 0.1767767, 0.35355339, 0.1767767, 0.,
+                         0., 0.],
+                        [0., 0., 0., 0., 0., 0., 0.]], 0.288)
     }
     node_dict = {
         'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
         'D': ["Crohn's Disease", 'Multiple Sclerosis'],
         'T': ['Leukocyte', 'Lung']
     }
-    if m_path == 'GaDaG':
-        dwwc_mat = numpy.array(mat_dict[m_path])
-        dwpc_mat = numpy.array(mat_dict['GaDaG_dwpc'])
-    else:
-        dwwc_mat = dwpc_mat = numpy.array(mat_dict[m_path])
+    type_dict = {
+        True: mattype if mattype else numpy.array,
+        False: sparse.csc_matrix
+    }
+
     row_names = node_dict[m_path[0]]
     col_names = node_dict[m_path[-1]]
-    return mattype, dwwc_mat, dwpc_mat, row_names, col_names
+
+    if m_path == 'GaDaG':
+        dwwc_mat = mat_dict['GaDaG'][0]
+        dwpc_mat = mat_dict['GaDaG_dwpc'][0]
+        type_dwwc = type_dict[mat_dict['GaDaG'][1] >= threshold]
+        type_dwpc = type_dict[mat_dict['GaDaG_dwpc'][1] >= threshold]
+    else:
+        dwwc_mat = dwpc_mat = mat_dict[m_path][0]
+        type_dwwc = type_dict[mat_dict[m_path][1] >= threshold]
+        type_dwpc = type_dict[mat_dict[m_path][1] >= threshold]
+
+    dwwc_mat = type_dwwc(dwwc_mat)
+    dwpc_mat = type_dwpc(dwpc_mat)
+
+    return type_dwwc, dwwc_mat, type_dwpc, dwpc_mat, row_names, col_names
 
 
-@pytest.mark.parametrize('auto', [True, False])
+@pytest.mark.parametrize('mattype', [sparse.csc_matrix])
+@pytest.mark.parametrize('thresh', (0, 0.2, 0.3, 0.5, 0.7, 0.9, 1))
 @pytest.mark.parametrize('m_path', ('GiGaD', 'GaDaG', 'GeTlD', 'GiG'))
-def test_dwpc_duplicated_metanode(m_path, auto):
+def test_dwpc_duplicated_metanode(m_path, thresh, mattype):
     """
     Test the ability of dwpc_duplicated_metanode to convert dwpc_matrix to a
     dense array when the percent nonzero goes above the 1/3 threshold. If auto
@@ -108,7 +120,6 @@ def test_dwpc_duplicated_metanode(m_path, auto):
     arrays when their densities exceeds 1/3.
    Checks output of dwpc_duplicated_metanode.
     """
-
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
         '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
         'test/data/disease-gene-example-graph.json',
@@ -118,24 +129,27 @@ def test_dwpc_duplicated_metanode(m_path, auto):
     metapath = metagraph.metapath_from_abbrev(m_path)
     dup = metapath.get_nodes()[0]
     rows, cols, dwwc_mat = dwpc_duplicated_metanode(
-        graph, metapath, damping=0.5, auto=auto, mat_type=sparse.csc_matrix,
-        duplicate=None)
+        graph, metapath, damping=0.5, mat_type=mattype,
+        duplicate=None, sparse_threshold=thresh)
     rows, cols, dwpc_mat = dwpc_duplicated_metanode(
-        graph, metapath, damping=0.5, auto=auto, mat_type=sparse.csc_matrix,
-        duplicate=dup)
+        graph, metapath, damping=0.5, mat_type=mattype,
+        duplicate=dup, sparse_threshold=thresh)
 
-    exp_type, exp_dwwc, exp_dwpc, exp_row, exp_col = get_expect(m_path, auto)
+    exp_type_dwwc, exp_dwwc, exp_type_dwpc, exp_dwpc, exp_row, exp_col = \
+        get_expect(m_path, thresh, mattype)
 
-    # Test AUTO mode
-    if exp_type == 'dense':
+    if exp_type_dwwc == numpy.array:
         assert isinstance(dwwc_mat, numpy.ndarray)
-        assert isinstance(dwpc_mat, numpy.ndarray)
     else:
         assert sparse.issparse(dwwc_mat)
+
+    if exp_type_dwpc == numpy.array:
+        assert isinstance(dwpc_mat, numpy.ndarray)
+    else:
         assert sparse.issparse(dwpc_mat)
 
     # Test matrix, row, and column label output
-    assert (dwwc_mat - exp_dwwc).sum() < 0.00001  # Assert approx equal
-    assert (dwpc_mat - exp_dwpc).sum() < 0.00001  # Assert approx equal
+    assert (dwwc_mat - exp_dwwc).sum() < 0.000001  # Assert approx equal
+    assert (dwpc_mat - exp_dwpc).sum() < 0.000001  # Assert approx equal
     assert rows == exp_row
     assert cols == exp_col

--- a/hetmech/test_degree_weight.py
+++ b/hetmech/test_degree_weight.py
@@ -135,7 +135,7 @@ def test_dwpc_duplicated_metanode(m_path, auto):
         assert sparse.issparse(dwpc_mat)
 
     # Test matrix, row, and column label output
-    assert (dwwc_mat - exp_dwwc).sum() < 0.00001  # Assert equal
-    assert (dwpc_mat - exp_dwpc).sum() < 0.00001  # Assert equal
+    assert (dwwc_mat - exp_dwwc).sum() < 0.00001  # Assert approx equal
+    assert (dwpc_mat - exp_dwpc).sum() < 0.00001  # Assert approx equal
     assert rows == exp_row
     assert cols == exp_col

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -68,4 +68,4 @@ def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):
     assert type(adj_mat) == type(exp_adj)
     assert adj_mat.dtype == dtype
     assert adj_mat.shape == exp_adj.shape
-    assert not (adj_mat != exp_adj).sum()
+    assert (adj_mat != exp_adj).sum() == 0

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -36,7 +36,7 @@ def get_arrays(edge, dtype, threshold):
     row_names = node_dict[edge[0]]
     col_names = node_dict[edge[-1]]
 
-    if adj_dict[edge][1] <= threshold:
+    if adj_dict[edge][1] < threshold:
         adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
     else:
         adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
@@ -44,7 +44,7 @@ def get_arrays(edge, dtype, threshold):
     return row_names, col_names, adj_matrix
 
 
-@pytest.mark.parametrize('threshold', [0, 0.5, 1])
+@pytest.mark.parametrize('threshold', [0, 0.25, 0.5, 1])
 @pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
 @pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
 def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -73,7 +73,7 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype):
 def test_meta_auto(test_edge, mat_type, auto):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating
-    arrays with automatic type. If the percent nonzero is above 30% of the
+    arrays with automatic type. If the percent nonzero is above 1/3 of the
     matrix, then the matrix will be a numpy.ndarray. Otherwise, the matrix
     will be a sparse.csc_matrix.
     """

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -6,7 +6,7 @@ from scipy import sparse
 from .matrix import metaedge_to_adjacency_matrix
 
 
-def get_arrays(edge, mat_type, dtype, threshold):
+def get_arrays(edge, dtype, threshold):
     node_dict = {
         'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
         'D': ["Crohn's Disease", 'Multiple Sclerosis'],
@@ -14,45 +14,39 @@ def get_arrays(edge, mat_type, dtype, threshold):
     }
     adj_dict = {
         'GiG': ([[0, 0, 1, 0, 1, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0],
-                [1, 1, 0, 1, 0, 0, 1],
-                [0, 0, 1, 0, 0, 0, 0],
-                [1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0]], 0.204),
+                 [0, 0, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 1, 0, 0, 1],
+                 [0, 0, 1, 0, 0, 0, 0],
+                 [1, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 1, 0, 0, 0, 0]], 0.204),
         'GaD': ([[0, 1],
-                [0, 1],
-                [1, 0],
-                [0, 1],
-                [0, 0],
-                [1, 1],
-                [0, 0]], 0.429),
+                 [0, 1],
+                 [1, 0],
+                 [0, 1],
+                 [0, 0],
+                 [1, 1],
+                 [0, 0]], 0.429),
         'DlT': ([[0, 0],
-                [1, 0]], 0.25),
+                 [1, 0]], 0.25),
         'TlD': ([[0, 1],
-                [0, 0]], 0.25)
+                 [0, 0]], 0.25)
     }
     row_names = node_dict[edge[0]]
     col_names = node_dict[edge[-1]]
 
-    if threshold:
-        if adj_dict[edge][1] <= threshold:
-            adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
-        else:
-            adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
-    elif mat_type:
-        adj_matrix = mat_type(adj_dict[edge][0], dtype=dtype)
+    if adj_dict[edge][1] <= threshold:
+        adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
     else:
         adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
+
     return row_names, col_names, adj_matrix
 
 
 @pytest.mark.parametrize('threshold', [0, 0.5, 1])
 @pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
-@pytest.mark.parametrize("mat_type", [numpy.array, sparse.csc_matrix,
-                                      sparse.csr_matrix, numpy.matrix, None])
 @pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
-def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype, threshold):
+def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating
     numpy arrays. Uses same test data as in test_degree_weight.py
@@ -65,11 +59,8 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype, threshold):
     )
     graph = hetio.readwrite.read_graph(url)
     row_names, col_names, adj_mat = metaedge_to_adjacency_matrix(
-            graph, test_edge, dtype=dtype, matrix_type=mat_type,
-            sparse_threshold=threshold
-        )
-    exp_row, exp_col, exp_adj = get_arrays(test_edge, mat_type, dtype,
-                                           threshold)
+            graph, test_edge, dtype=dtype, sparse_threshold=threshold)
+    exp_row, exp_col, exp_adj = get_arrays(test_edge, dtype, threshold)
 
     assert row_names == exp_row
     assert col_names == exp_col
@@ -77,27 +68,3 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype, threshold):
     assert adj_mat.dtype == dtype
     assert adj_mat.shape == exp_adj.shape
     assert not (adj_mat != exp_adj).sum()
-
-
-@pytest.mark.parametrize('mat_type', [numpy.ndarray, sparse.csc_matrix, None])
-@pytest.mark.parametrize("threshold", [1, 0])
-@pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
-def test_meta_auto(test_edge, mat_type, threshold):
-    """
-    Test the functionality of metaedge_to_adjacency_matrix in generating
-    arrays with automatic type. If the percent nonzero is above threshold,
-    then the matrix will be a numpy.ndarray. Otherwise, the matrix will
-    be a sparse.csc_matrix.
-    """
-    url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
-        '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
-        'test/data/disease-gene-example-graph.json',
-    )
-    graph = hetio.readwrite.read_graph(url)
-    row, col, adj = metaedge_to_adjacency_matrix(
-        graph, test_edge, sparse_threshold=threshold, matrix_type=mat_type)
-
-    auto_to_mat_type = {1: sparse.csc_matrix,
-                        0: mat_type if mat_type else numpy.ndarray}
-
-    assert type(adj) == auto_to_mat_type[threshold]

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -64,7 +64,7 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype):
     assert type(adj_mat) == type(exp_adj)
     assert adj_mat.dtype == dtype
     assert adj_mat.shape == exp_adj.shape
-    assert (adj_mat != exp_adj).sum() == 0
+    assert not (adj_mat != exp_adj).sum()
 
 
 @pytest.mark.parametrize('mat_type', [numpy.ndarray, sparse.csc_matrix])

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -7,11 +7,7 @@ from .matrix import metaedge_to_adjacency_matrix
 
 
 def get_arrays(edge, dtype, threshold):
-    node_dict = {
-        'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
-        'D': ["Crohn's Disease", 'Multiple Sclerosis'],
-        'T': ['Leukocyte', 'Lung']
-    }
+    # Dictionary with tuples of matrix and percent nonzero
     adj_dict = {
         'GiG': ([[0, 0, 1, 0, 1, 0, 0],
                  [0, 0, 1, 0, 0, 0, 0],
@@ -31,6 +27,11 @@ def get_arrays(edge, dtype, threshold):
                  [1, 0]], 0.25),
         'TlD': ([[0, 1],
                  [0, 0]], 0.25)
+    }
+    node_dict = {
+        'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
+        'D': ["Crohn's Disease", 'Multiple Sclerosis'],
+        'T': ['Leukocyte', 'Lung']
     }
     row_names = node_dict[edge[0]]
     col_names = node_dict[edge[-1]]

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -6,43 +6,53 @@ from scipy import sparse
 from .matrix import metaedge_to_adjacency_matrix
 
 
-def get_arrays(edge, mat_type, dtype):
+def get_arrays(edge, mat_type, dtype, threshold):
     node_dict = {
         'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
         'D': ["Crohn's Disease", 'Multiple Sclerosis'],
         'T': ['Leukocyte', 'Lung']
     }
     adj_dict = {
-        'GiG': [[0, 0, 1, 0, 1, 0, 0],
+        'GiG': ([[0, 0, 1, 0, 1, 0, 0],
                 [0, 0, 1, 0, 0, 0, 0],
                 [1, 1, 0, 1, 0, 0, 1],
                 [0, 0, 1, 0, 0, 0, 0],
                 [1, 0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 0, 0, 0, 0]],
-        'GaD': [[0, 1],
+                [0, 0, 1, 0, 0, 0, 0]], 0.204),
+        'GaD': ([[0, 1],
                 [0, 1],
                 [1, 0],
                 [0, 1],
                 [0, 0],
                 [1, 1],
-                [0, 0]],
-        'DlT': [[0, 0],
-                [1, 0]],
-        'TlD': [[0, 1],
-                [0, 0]]
+                [0, 0]], 0.429),
+        'DlT': ([[0, 0],
+                [1, 0]], 0.25),
+        'TlD': ([[0, 1],
+                [0, 0]], 0.25)
     }
     row_names = node_dict[edge[0]]
     col_names = node_dict[edge[-1]]
-    adj_matrix = mat_type(adj_dict[edge], dtype=dtype)
+
+    if threshold:
+        if adj_dict[edge][1] <= threshold:
+            adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
+        else:
+            adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
+    elif mat_type:
+        adj_matrix = mat_type(adj_dict[edge][0], dtype=dtype)
+    else:
+        adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
     return row_names, col_names, adj_matrix
 
 
+@pytest.mark.parametrize('threshold', [0, 0.5, 1])
 @pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
 @pytest.mark.parametrize("mat_type", [numpy.array, sparse.csc_matrix,
-                                      sparse.csr_matrix, numpy.matrix])
+                                      sparse.csr_matrix, numpy.matrix, None])
 @pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
-def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype):
+def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype, threshold):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating
     numpy arrays. Uses same test data as in test_degree_weight.py
@@ -54,10 +64,12 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype):
         'test/data/disease-gene-example-graph.json',
     )
     graph = hetio.readwrite.read_graph(url)
-    row_names, col_names, adj_mat = \
-        metaedge_to_adjacency_matrix(graph, test_edge, dtype=dtype,
-                                     matrix_type=mat_type)
-    exp_row, exp_col, exp_adj = get_arrays(test_edge, mat_type, dtype)
+    row_names, col_names, adj_mat = metaedge_to_adjacency_matrix(
+            graph, test_edge, dtype=dtype, matrix_type=mat_type,
+            sparse_threshold=threshold
+        )
+    exp_row, exp_col, exp_adj = get_arrays(test_edge, mat_type, dtype,
+                                           threshold)
 
     assert row_names == exp_row
     assert col_names == exp_col
@@ -67,30 +79,25 @@ def test_metaedge_to_adjacency_matrix(test_edge, mat_type, dtype):
     assert not (adj_mat != exp_adj).sum()
 
 
-@pytest.mark.parametrize('mat_type', [numpy.ndarray, sparse.csc_matrix])
-@pytest.mark.parametrize("auto", [True, False])
+@pytest.mark.parametrize('mat_type', [numpy.ndarray, sparse.csc_matrix, None])
+@pytest.mark.parametrize("threshold", [1, 0])
 @pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
-def test_meta_auto(test_edge, mat_type, auto):
+def test_meta_auto(test_edge, mat_type, threshold):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating
-    arrays with automatic type. If the percent nonzero is above 1/3 of the
-    matrix, then the matrix will be a numpy.ndarray. Otherwise, the matrix
-    will be a sparse.csc_matrix.
+    arrays with automatic type. If the percent nonzero is above threshold,
+    then the matrix will be a numpy.ndarray. Otherwise, the matrix will
+    be a sparse.csc_matrix.
     """
     url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
         '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
         'test/data/disease-gene-example-graph.json',
     )
     graph = hetio.readwrite.read_graph(url)
-    row, col, adj = metaedge_to_adjacency_matrix(graph, test_edge, auto=auto,
-                                                 matrix_type=mat_type)
+    row, col, adj = metaedge_to_adjacency_matrix(
+        graph, test_edge, sparse_threshold=threshold, matrix_type=mat_type)
 
-    # Define a dict with adjacency matrices having known percent nonzero
-    edge_to_nnz = {'GiG': sparse.csc_matrix,
-                   'GaD': numpy.ndarray,
-                   'DlT': sparse.csc_matrix,
-                   'TlD': sparse.csc_matrix}
-    auto_to_mat_type = {True: edge_to_nnz[test_edge],
-                        False: mat_type}
+    auto_to_mat_type = {1: sparse.csc_matrix,
+                        0: mat_type if mat_type else numpy.ndarray}
 
-    assert type(adj) == auto_to_mat_type[auto]
+    assert type(adj) == auto_to_mat_type[threshold]

--- a/hetmech/test_matrix.py
+++ b/hetmech/test_matrix.py
@@ -45,8 +45,8 @@ def get_arrays(edge, dtype, threshold):
 
 
 @pytest.mark.parametrize('threshold', [0, 0.25, 0.5, 1])
-@pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
 @pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
+@pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
 def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating

--- a/hetmech/test_path_count.py
+++ b/hetmech/test_path_count.py
@@ -1,7 +1,6 @@
-import numpy
-
 import hetio.pathtools
 import hetio.readwrite
+import numpy
 import pytest
 
 from .degree_weight import dwpc, get_segments
@@ -60,7 +59,7 @@ def test_CbGpPWpGaD_traversal():
     """
     graph = get_bupropion_subgraph()
     compound = 'DB01156'  # Bupropion
-    disease = 'DOID:0050742'  # nicotine dependences
+    disease = 'DOID:0050742'  # nicotine dependencies
     metapath = graph.metagraph.metapath_from_abbrev('CbGpPWpGaD')
     rows, cols, pc_matrix = dwpc(graph, metapath, damping=0)
     rows, cols, dwpc_matrix = dwpc(graph, metapath, damping=0.4)
@@ -79,7 +78,7 @@ def test_CbGiGiGaD_traversal():
     """
     graph = get_bupropion_subgraph()
     compound = 'DB01156'  # Bupropion
-    disease = 'DOID:0050742'  # nicotine dependences
+    disease = 'DOID:0050742'  # nicotine dependencies
     metapath = graph.metagraph.metapath_from_abbrev('CbGiGiGaD')
     paths = hetio.pathtools.paths_between(
         graph,

--- a/hetmech/test_path_count.py
+++ b/hetmech/test_path_count.py
@@ -59,7 +59,7 @@ def test_CbGpPWpGaD_traversal():
     """
     graph = get_bupropion_subgraph()
     compound = 'DB01156'  # Bupropion
-    disease = 'DOID:0050742'  # nicotine dependencies
+    disease = 'DOID:0050742'  # nicotine dependence
     metapath = graph.metagraph.metapath_from_abbrev('CbGpPWpGaD')
     rows, cols, pc_matrix = dwpc(graph, metapath, damping=0)
     rows, cols, dwpc_matrix = dwpc(graph, metapath, damping=0.4)
@@ -78,7 +78,7 @@ def test_CbGiGiGaD_traversal():
     """
     graph = get_bupropion_subgraph()
     compound = 'DB01156'  # Bupropion
-    disease = 'DOID:0050742'  # nicotine dependencies
+    disease = 'DOID:0050742'  # nicotine dependence
     metapath = graph.metagraph.metapath_from_abbrev('CbGiGiGaD')
     paths = hetio.pathtools.paths_between(
         graph,

--- a/hetmech/xarray.py
+++ b/hetmech/xarray.py
@@ -23,7 +23,7 @@ def metaedge_to_data_array(graph, metaedge, dtype=numpy.bool_):
     are columns and target nodes are rows.
     """
     source_node_ids, target_node_ids, adjacency_matrix = (
-        metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_))
+        metaedge_to_adjacency_matrix(graph, metaedge, dtype=dtype))
 
     dims = metaedge.source.identifier, metaedge.target.identifier
     coords = source_node_ids, target_node_ids


### PR DESCRIPTION
Closes https://github.com/greenelab/hetmech/issues/13
Closes https://github.com/greenelab/hetmech/issues/43

Updated method for row and column sums to ensure that both numpy.ndarrays and scipy.sparse matrices sums over axes 0 and 1 return a dimension 1 numpy.ndarray with the respective row/column sums. 

Added a function parameter to set a threshold above whose density the matrix should be converted to dense.

diffusion node_scores would be a dense, 1 dimensional array, which works with sparse or dense multiplication