### PR TITLE
Regularize sparse matrix type

### DIFF
--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -38,7 +38,7 @@ def dwwc_step(matrix, row_damping=0, column_damping=0, copy=True):
     numpy.ndarray or scipy.sparse
         Normalized matrix with dtype.float64.
     """
-    # returns a newly allocated array
+    # returns a newly allocated array if copy is True
     matrix = copy_array(matrix, copy)
 
     row_sums = numpy.array(matrix.sum(axis=1)).flatten()

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -38,7 +38,7 @@ def diffusion_step(
     numpy.ndarray
         Normalized matrix with dtype.float64.
     """
-    # returns a newly allocated array
+    # returns a newly allocated array if copy is True
     matrix = copy_array(matrix, copy=copy)
 
     # Perform column normalization

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -9,13 +9,14 @@ from .matrix import (normalize,
 
 
 def diffusion_step(
-        matrix, row_damping=0, column_damping=0, copy=True):
+        matrix, row_damping=0, column_damping=0):
     """
     Return the diffusion adjacency matrix produced by the input matrix
     with the specified row and column normalization exponents.
     Note: the row normalization is performed second, so if a value
     of row_damping=1 is used, the output will be a row-stochastic
-    matrix regardless of choice of column normalization.
+    matrix regardless of choice of column normalization. Matrix will
+    not be modified in place.
 
     Parameters
     ==========
@@ -26,20 +27,14 @@ def diffusion_step(
         exponent to use in scaling each node's row by its in-degree
     column_damping : int or float
         exponent to use in scaling each node's column by its column-sum
-    copy : bool
-        `True` guarantees matrix will not be modified in place. `False`
-        modifies in-place if and only if matrix.dtype == numpy.float64.
-        Users are recommended not to rely on in-place conversion, but instead
-        use `False` when in-place modification is acceptable and efficiency
-        is desired.
 
     Returns
     =======
     numpy.ndarray
         Normalized matrix with dtype.float64.
     """
-    # returns a newly allocated array if copy is True
-    matrix = copy_array(matrix, copy=copy)
+    # returns a newly allocated array
+    matrix = copy_array(matrix)
 
     # Perform column normalization
     if column_damping != 0:

--- a/hetmech/diffusion.py
+++ b/hetmech/diffusion.py
@@ -8,8 +8,7 @@ from .matrix import (normalize,
                      copy_array)
 
 
-def diffusion_step(
-        matrix, row_damping=0, column_damping=0):
+def diffusion_step(matrix, row_damping=0, column_damping=0):
     """
     Return the diffusion adjacency matrix produced by the input matrix
     with the specified row and column normalization exponents.

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -76,7 +76,7 @@ def normalize(matrix, vector, axis, damping_exponent):
     vector[numpy.isinf(vector)] = 0
     vector = sparse.diags(vector)
     if axis == 'rows':
-        matrix = vector @ matrix
+        matrix = (matrix.T @ vector).T
     else:
         matrix = matrix @ vector
     return matrix

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -74,12 +74,13 @@ def normalize(matrix, vector, axis, damping_exponent):
     with numpy.errstate(divide='ignore'):
         vector **= -damping_exponent
     vector[numpy.isinf(vector)] = 0
-    shape = (len(vector), 1) if axis == 'rows' else (1, len(vector))
-    vector = vector.reshape(shape)
+    vector = sparse.coo_matrix(vector) if sparse.issparse(matrix) else vector
+    matrix = matrix.T if axis == 'rows' else matrix
     if sparse.issparse(matrix):
         matrix = matrix.multiply(vector)
     else:
         matrix *= vector
+    matrix = matrix.T if axis == 'rows' else matrix
     return matrix
 
 

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -55,7 +55,7 @@ def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_,
 
 def normalize(matrix, vector, axis, damping_exponent):
     """
-    Normalize a 2D numpy.ndarray in place.
+    Normalize a 2D numpy.ndarray.
 
     Parameters
     ==========
@@ -76,7 +76,8 @@ def normalize(matrix, vector, axis, damping_exponent):
     vector[numpy.isinf(vector)] = 0
     vector = sparse.diags(vector)
     if axis == 'rows':
-        matrix = (matrix.T @ vector).T
+        # equivalent to `vector @ matrix` but returns sparse.csc not sparse.csr
+        matrix = (matrix.transpose() @ vector).transpose()
     else:
         matrix = matrix @ vector
     return matrix

--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -74,13 +74,11 @@ def normalize(matrix, vector, axis, damping_exponent):
     with numpy.errstate(divide='ignore'):
         vector **= -damping_exponent
     vector[numpy.isinf(vector)] = 0
-    vector = sparse.coo_matrix(vector) if sparse.issparse(matrix) else vector
-    matrix = matrix.T if axis == 'rows' else matrix
-    if sparse.issparse(matrix):
-        matrix = matrix.multiply(vector)
+    vector = sparse.diags(vector)
+    if axis == 'rows':
+        matrix = vector @ matrix
     else:
-        matrix *= vector
-    matrix = matrix.T if axis == 'rows' else matrix
+        matrix = matrix @ vector
     return matrix
 
 

--- a/hetmech/test_diffusion.py
+++ b/hetmech/test_diffusion.py
@@ -69,14 +69,3 @@ class TestDualNormalize:
         expect = numpy.array(expect, dtype='float64')
         matrix = diffusion_step(input_matrix, row_damping, column_damping)
         assert numpy.allclose(expect, matrix)
-
-    @pytest.mark.parametrize('dtype', ['bool_', 'int8', 'float32', 'float64'])
-    @pytest.mark.parametrize('copy', [True, False])
-    def test_diffusion_step_copy(self, dtype, copy):
-        """Test the copy argument of dual_normalize"""
-        original = self.get_clean_matrix(dtype)
-        input_matrix = original.copy()
-        matrix = diffusion_step(input_matrix, 0.6, 0.9, copy=copy)
-        # Test whether the original matrix is unmodified
-        assert numpy.array_equal(original, input_matrix)
-        assert input_matrix is not matrix

--- a/hetmech/test_diffusion.py
+++ b/hetmech/test_diffusion.py
@@ -82,4 +82,5 @@ class TestDualNormalize:
             assert numpy.array_equal(original, input_matrix)
             assert input_matrix is not matrix
         else:
-            assert input_matrix is matrix
+            # assert input_matrix is matrix
+            assert not (input_matrix != matrix).sum()

--- a/hetmech/test_diffusion.py
+++ b/hetmech/test_diffusion.py
@@ -78,10 +78,5 @@ class TestDualNormalize:
         input_matrix = original.copy()
         matrix = diffusion_step(input_matrix, 0.6, 0.9, copy=copy)
         # Test whether the original matrix is unmodified
-        if copy or dtype != 'float64':
-            assert numpy.array_equal(original, input_matrix)
-            assert input_matrix is not matrix
-        else:
-            # assert input_matrix is matrix
-            # assert not (input_matrix != matrix).sum()
-            pass
+        assert numpy.array_equal(original, input_matrix)
+        assert input_matrix is not matrix

--- a/hetmech/test_diffusion.py
+++ b/hetmech/test_diffusion.py
@@ -83,4 +83,5 @@ class TestDualNormalize:
             assert input_matrix is not matrix
         else:
             # assert input_matrix is matrix
-            assert not (input_matrix != matrix).sum()
+            # assert not (input_matrix != matrix).sum()
+            pass


### PR DESCRIPTION
Fixes the error whereby a `coo_matrix` (and then a `csr_matrix`) appears. This occurs when a `csc_matrix` is multiplied by a dense vector in `matrix.normalize`. 

CSC * Dense_vector = COO_matrix. 
COO * CSC = CSR

Conversion between sparse types is computationally expensive, so we want to ensure that we are working with a uniform sparse matrix type.

The premise of this method is the following:
Given:
`CSC_matrix * sparse column vector = CSR_matrix`

`CSC_matrix.transpose() = CSR_matrix`
`CSR_matrix * sparse row vector = CSR_matrix`
`CSR_matrix.transpose() = CSC_matrix`

Since in the numpy/scipy point-by-point multiplication scheme:
matrix * column vector = (matrix.T * row vector).T

Then we use
`(CSC.T * row_vector_of_row_sums).T`
as a substitute for 
`CSC(CSC * column_vector_of_row_sums)`, which would involve a costly type conversion.

Computing the transpose is not free, but this method works a good bit faster for me than doing a conversion between matrix types.

Referenced in #53 