### PR TITLE
Add DWPC functionality for BAAB case

### DIFF
--- a/hetmech/dwpc.py
+++ b/hetmech/dwpc.py
@@ -47,7 +47,8 @@ def dwpc_baab(graph, metapath, damping=0.5):
     A function to handle metapath (segments) of the form BAAB.
     This function will handle arbitrary lengths of this repeated
     pattern. For example, ABCCBA, ABCDDCBA, etc. all work with this
-    function. As it stands, random single inserts are not supported.
+    function. Random non-repeat inserts are supported. The metapath
+    must start and end with a repeated node, though.
     """
     metanodes = list(metapath.get_nodes())
     repeated_nodes = [v for i, v in enumerate(metanodes) if

--- a/hetmech/dwpc.py
+++ b/hetmech/dwpc.py
@@ -61,7 +61,8 @@ def dwpc_baab(graph, metapath, damping=0.5):
 
     for metaedge in metapath[first_inner:second_inner]:
         row, col, adj = metaedge_to_adjacency_matrix(graph, metaedge,
-                                                     np.float64)
+                                                     numpy.float64)
+        adj = degree_weight(adj, damping)
         if dwpc_inner is None:
             dwpc_inner = adj
         else:
@@ -75,6 +76,8 @@ def dwpc_baab(graph, metapath, damping=0.5):
                     graph, metapath[first_ind - 1])[2]
                 adj2 = metaedge_to_adjacency_matrix(
                     graph, metapath[last_ind])[2]
+                adj1 = degree_weight(adj1, damping)
+                adj2 = degree_weight(adj2, damping)
 
                 inner_array = adj1 @ (inner_array @ adj2)
                 inner_array = remove_diag(inner_array)
@@ -82,10 +85,12 @@ def dwpc_baab(graph, metapath, damping=0.5):
             else:
                 adj = metaedge_to_adjacency_matrix(
                     graph, metapath[first_ind - 1])[2]
+                adj = degree_weight(adj, damping)
                 inner_array = adj @ inner_array
                 first_ind -= 1
         else:
             adj = metaedge_to_adjacency_matrix(graph, metapath[last_ind])[2]
+            adj = degree_weight(adj, damping)
             inner_array = inner_array @ adj
             last_ind += 1
         if len(metapath) == last_ind - first_ind:
@@ -93,7 +98,12 @@ def dwpc_baab(graph, metapath, damping=0.5):
         else:
             return next_outer(first_ind, last_ind, inner_array)
 
-    return next_outer(first_inner, second_inner, dwpc_inner)
+    row_names = metaedge_to_adjacency_matrix(
+        graph, metapath[0], dtype=numpy.float64)[0]
+    col_names = metaedge_to_adjacency_matrix(
+        graph, metapath[-1], dtype=numpy.float64)[1]
+    dwpc_matrix = next_outer(first_inner, second_inner, dwpc_inner)
+    return row_names, col_names, dwpc_matrix
 
 
 def dwpc_baba(graph, metapath, damping=0.5):

--- a/hetmech/dwpc.py
+++ b/hetmech/dwpc.py
@@ -60,6 +60,7 @@ def dwpc_baab(graph, metapath, damping=0.5):
 
     dwpc_inner = None
 
+    # Traverse between and including innermost repeated metanodes
     for metaedge in metapath[first_inner:second_inner]:
         row, col, adj = metaedge_to_adjacency_matrix(graph, metaedge,
                                                      numpy.float64)
@@ -71,7 +72,27 @@ def dwpc_baab(graph, metapath, damping=0.5):
     dwpc_inner = remove_diag(dwpc_inner)
 
     def next_outer(first_ind, last_ind, inner_array):
+        """
+        A recursive function. Works outward from the middle of a
+        metapath. Multiplies non-repeat metanodes as appropriate and
+        builds outward. When identical metanodes are ahead of and
+        behind the middle segment being worked with, this function
+        multiplies by both and subtracts the main diagonal.
+
+        Parameters
+        ----------
+        first_ind : int
+            index at the beginning of the middle segment
+        last_ind : int
+            index at the end of the middle segment
+        inner_array : numpy.ndarray
+            The working dwpc_matrix, which is multiplied from the front
+            and back depending on which side has a duplicated metanode
+            at the closest position
+        """
+        # case where node at the end is a repeated metanode
         if metanodes[last_ind + 1] in repeated_nodes:
+            # if middle segment surrounded by repeated metanodes
             if metanodes[first_ind - 1] == metanodes[last_ind + 1]:
                 adj1 = metaedge_to_adjacency_matrix(
                     graph, metapath[first_ind - 1])[2]
@@ -83,22 +104,26 @@ def dwpc_baab(graph, metapath, damping=0.5):
                 inner_array = adj1 @ (inner_array @ adj2)
                 inner_array = remove_diag(inner_array)
                 first_ind, last_ind = first_ind - 1, last_ind + 1
+            # only trailing metanode is a repeat
             else:
                 adj = metaedge_to_adjacency_matrix(
                     graph, metapath[first_ind - 1])[2]
                 adj = degree_weight(adj, damping)
                 inner_array = adj @ inner_array
                 first_ind -= 1
+        # trailing metanode is not a repeated
         else:
             adj = metaedge_to_adjacency_matrix(graph, metapath[last_ind])[2]
             adj = degree_weight(adj, damping)
             inner_array = inner_array @ adj
             last_ind += 1
+        # the middle segment spans the entire metapath
         if len(metapath) == last_ind - first_ind:
             return inner_array
         else:
             return next_outer(first_ind, last_ind, inner_array)
 
+    # get source and target ID arrays
     row_names = metaedge_to_adjacency_matrix(
         graph, metapath[0], dtype=numpy.float64)[0]
     col_names = metaedge_to_adjacency_matrix(

--- a/hetmech/dwpc.py
+++ b/hetmech/dwpc.py
@@ -1,7 +1,6 @@
 import functools
 import operator
 
-import hetio.hetnet
 import numpy
 
 from .matrix import metaedge_to_adjacency_matrix, normalize, copy_array

--- a/hetmech/test_dwpc.py
+++ b/hetmech/test_dwpc.py
@@ -36,6 +36,6 @@ def test_dwpc_baab(metapath, expected):
 
     expected = numpy.array(expected, dtype=numpy.float64)
 
-    assert pytest.approx(numpy.max(dwpc_matrix - expected) == 0)
+    assert abs(dwpc_matrix - expected).sum() == pytest.approx(0, abs=1e-7)
     assert exp_row == row
     assert exp_col == col

--- a/hetmech/test_dwpc.py
+++ b/hetmech/test_dwpc.py
@@ -1,0 +1,40 @@
+import hetio.readwrite
+import pytest
+
+from .dwpc import *
+
+
+@pytest.mark.parametrize('metapath,expected', [
+    ('DaGiGaD', [[0., 0.47855339],
+                 [0.47855339, 0.]]),
+    ('TeGiGeT', [[0, 0],
+                 [0, 0]]),
+    ('DlTeGiGaD', [[0, 0],
+                   [0, 0]]),
+    ('DaGeTeGaD', [[0, 0],
+                   [0, 0]]),
+    ('TlDaGiGeT', [[0., 0.47855339],
+                   [0., 0.]])
+])
+def test_dwpc_baab(metapath, expected):
+    node_dict = {
+        'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
+        'D': ["Crohn's Disease", 'Multiple Sclerosis'],
+        'T': ['Leukocyte', 'Lung']
+    }
+    exp_row = node_dict[metapath[0]]
+    exp_col = node_dict[metapath[-1]]
+    url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
+        '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
+        'test/data/disease-gene-example-graph.json',
+    )
+    graph = hetio.readwrite.read_graph(url)
+    metapath = graph.metagraph.metapath_from_abbrev(metapath)
+
+    row, col, dwpc_matrix = dwpc_baab(graph, metapath, damping=0.5)
+
+    expected = numpy.array(expected, dtype=numpy.float64)
+
+    assert pytest.approx(numpy.max(dwpc_matrix - expected) == 0)
+    assert exp_row == row
+    assert exp_col == col

--- a/hetmech/test_dwpc.py
+++ b/hetmech/test_dwpc.py
@@ -1,7 +1,8 @@
 import hetio.readwrite
+import numpy
 import pytest
 
-from .dwpc import *
+from .dwpc import dwpc_baab
 
 
 @pytest.mark.parametrize('metapath,expected', [

--- a/hetmech/test_dwpc.py
+++ b/hetmech/test_dwpc.py
@@ -10,7 +10,7 @@ from .dwpc import dwpc_baab
                  [0.47855339, 0.]]),
     ('TeGiGeT', [[0, 0],
                  [0, 0]]),
-    ('DlTeGiGaD', [[0, 0],
+    ('DaGiGeTlD', [[0, 0],
                    [0, 0]]),
     ('DaGeTeGaD', [[0, 0],
                    [0, 0]]),


### PR DESCRIPTION
Adds a function that covers all variants of BAAB, including any length repeats in a symmetric pattern like DCBAABCD, as well as random (variable length) inserts of non-repeated nodes anywhere in the pattern.

Acceptable metapaths for this function include the following:
`B-A-A-B`
`B-C-A-A-B`
`B-C-A-D-A-E-B`
`B-C-D-E-A-F-A-B`