### PR TITLE
Add setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
   - conda env create --quiet --file environment.yml
   - source activate hetmech
+  - pip install --editable .
 script:
   - pytest hetmech
   - jupyter nbconvert --to=script --stdout *.ipynb |

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ The method is designed to operate on hetnets (networks with multiple node or rel
 
 This project is still under development. Use with caution.
 
-To use hetmech as a package:
-
-`pip install --editable .`
-
 ## Environment
 
 This repository uses [conda](http://conda.pydata.org/docs/) to manage its environment as specified in [`environment.yml`](environment.yml).
@@ -21,6 +17,10 @@ conda env create --file=environment.yml
 ```
 
 Then use `source activate hetmech` and `source deactivate` to activate or deactivate the environment.
+
+For local development, run the following with the hetmech environment activated:
+
+`pip install --editable .`
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 [![Build Status](https://travis-ci.org/greenelab/hetmech.svg?branch=master)](https://travis-ci.org/greenelab/hetmech)
 
 Hetmech aims to identify the relevant network connections between a set of query nodes.
-The method is designed to operate on hetnets (networks with multiple node or relationship types). 
+The method is designed to operate on hetnets (networks with multiple node or relationship types).
 
 This project is still under development. Use with caution.
+
+To use hetmech as a package:
+
+`pip install --editable .`
 
 ## Environment
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import setup
 
-from pip.req import parse_requirements
-install_reqs = parse_requirements('environment.yml')
-
 setup(name='hetmech',
       description='A search engine for hetnets',
       long_description='Matrix implementations of path-count-based measures',

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(name='hetmech',
       url='https://github.com/greenelab/hetmech',
       license='BSD 3-Clause License',
       packages=['hetmech'],
-      install_requires=['hetio']
+      install_requires=['hetio==0.2.8', 'numpy=1.13.1', 'scipy=0.19.1',
+                        'xarray=0.9.6']
       )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setup(name='hetmech',
       url='https://github.com/greenelab/hetmech',
       license='BSD 3-Clause License',
       packages=['hetmech'],
-      install_requires=['hetio==0.2.8', 'numpy==1.13.1', 'scipy==0.19.1',
-                        'xarray==0.9.6']
+      install_requires=[
+          'hetio>=0.2.8',
+          'numpy',
+          'scipy',
+          'xarray']
       )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(name='hetmech',
+      description='A search engine for hetnets',
+      long_description='Matrix implementations of path-count-based measures',
+      url='https://github.com/greenelab/hetmech',
+      license='BSD 3-Clause License',
+      packages=['hetmech'],
+      )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='hetmech',
       url='https://github.com/greenelab/hetmech',
       license='BSD 3-Clause License',
       packages=['hetmech'],
-      install_requires=['hetio==0.2.8', 'numpy=1.13.1', 'scipy=0.19.1',
-                        'xarray=0.9.6']
+      install_requires=['hetio==0.2.8', 'numpy==1.13.1', 'scipy==0.19.1',
+                        'xarray==0.9.6']
       )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 
+from pip.req import parse_requirements
+install_reqs = parse_requirements('environment.yml')
+
 setup(name='hetmech',
       description='A search engine for hetnets',
       long_description='Matrix implementations of path-count-based measures',
       url='https://github.com/greenelab/hetmech',
       license='BSD 3-Clause License',
       packages=['hetmech'],
+      install_requires=['hetio']
       )

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(name='hetmech',
           'hetio>=0.2.8',
           'numpy',
           'scipy',
-          'xarray']
+          'xarray',
+          ]
       )


### PR DESCRIPTION
This PR adds a minimal `setup.py` which allows Hetmech to be imported with pip using 
`pip install git+https://github.com/greenelab/hetmech.git@{commit}`

There should be a better way of specifying the install requirements, perhaps using a `requirements.txt` file containing just the necessary components of `environment.yml`.