### PR TITLE
Add DWPC approximation method

### DIFF
--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -116,6 +116,9 @@ def dwpc(graph, metapath, damping=0.5, dense_threshold=0, approx_ok=False,
     """
     category = categorize(metapath)
     dwpc_function = _category_to_function(category, dwwc_method=dwwc_method, approx_ok=approx_ok)
+    if category in ('long_repeat', 'other') and not approx_ok:
+        logging.warning(f"Metapath {metapath} will use _dwpc_general_case, "
+                        "which can require very long computations.")
     row_names, col_names, dwpc_matrix = dwpc_function(
         graph, metapath, damping, dense_threshold=dense_threshold,
         dtype=dtype)

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -20,7 +20,7 @@ from hetmech.matrix import (
 )
 
 
-def _category_to_function(category, dwwc_method, approx_ok):
+def _category_to_function(category, dwwc_method):
     function_dictionary = {
         'no_repeats': dwwc_method,
         'disjoint': _dwpc_disjoint,
@@ -34,9 +34,6 @@ def _category_to_function(category, dwwc_method, approx_ok):
         'interior_complete_group': _dwpc_baba,
         'other': _dwpc_approx,
     }
-    if approx_ok:
-        function_dictionary.update({'long_repeat': _dwpc_general_case,
-                                    'other': _dwpc_general_case})
     return function_dictionary[category]
 
 
@@ -115,10 +112,13 @@ def dwpc(graph, metapath, damping=0.5, dense_threshold=0, approx_ok=False,
         the DWPC matrix
     """
     category = categorize(metapath)
-    dwpc_function = _category_to_function(category, dwwc_method=dwwc_method, approx_ok=approx_ok)
-    if category in ('long_repeat', 'other') and not approx_ok:
-        logging.warning(f"Metapath {metapath} will use _dwpc_general_case, "
-                        "which can require very long computations.")
+    dwpc_function = _category_to_function(category, dwwc_method=dwwc_method)
+    if category in ('long_repeat', 'other'):
+        if approx_ok:
+            dwpc_function = _dwpc_approx
+        else:
+            logging.warning(f"Metapath {metapath} will use _dwpc_general_case, "
+                            "which can require very long computations.")
     row_names, col_names, dwpc_matrix = dwpc_function(
         graph, metapath, damping, dense_threshold=dense_threshold,
         dtype=dtype)

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -598,6 +598,7 @@ def _dwpc_approx(graph, metapath, damping=0.5, dense_threshold=0,
         _, cols, tail_seg = dwpc(graph, metapath[repeated_indices[-1]:], damping=damping,
                                  dense_threshold=dense_threshold, dtype=dtype)
         dwpc_matrix = dwpc_matrix @ tail_seg
+    dwpc_matrix = sparsify_or_densify(dwpc_matrix, dense_threshold)
     return row_names, cols, dwpc_matrix
 
 

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -20,7 +20,7 @@ from hetmech.matrix import (
 )
 
 
-def _category_to_function(category, dwwc_method, use_general):
+def _category_to_function(category, dwwc_method, approx_ok):
     function_dictionary = {
         'no_repeats': dwwc_method,
         'disjoint': _dwpc_disjoint,
@@ -34,7 +34,7 @@ def _category_to_function(category, dwwc_method, use_general):
         'interior_complete_group': _dwpc_baba,
         'other': _dwpc_approx,
     }
-    if use_general:
+    if approx_ok:
         function_dictionary.update({'long_repeat': _dwpc_general_case,
                                     'other': _dwpc_general_case})
     return function_dictionary[category]
@@ -79,7 +79,7 @@ def path_count_cache(metric):
 
 
 @path_count_cache(metric='dwpc')
-def dwpc(graph, metapath, damping=0.5, dense_threshold=0, use_general=False,
+def dwpc(graph, metapath, damping=0.5, dense_threshold=0, approx_ok=False,
          dtype=numpy.float64, dwwc_method=None):
     """
     A unified function to compute the degree-weighted path count.
@@ -94,10 +94,10 @@ def dwpc(graph, metapath, damping=0.5, dense_threshold=0, use_general=False,
     dense_threshold : float (0 <= dense_threshold <= 1)
         sets the density threshold above which a sparse matrix will be
         converted to a dense automatically.
-    use_general : bool
-        if True, dwpc will call _dwpc_general_case and give a warning
-        on metapaths which are categorized 'other' and 'long_repeat'.
-        If False, uses an approximation to DWPC.
+    approx_ok : bool
+        if True, uses an approximation to DWPC. If False, dwpc will call
+        _dwpc_general_case and give a warning on metapaths which are
+        categorized 'other' and 'long_repeat'..
     dtype : dtype object
         numpy.float32 or numpy.float64. At present, numpy.float16 fails when
         using sparse matrices, due to a bug in scipy.sparse
@@ -115,7 +115,7 @@ def dwpc(graph, metapath, damping=0.5, dense_threshold=0, use_general=False,
         the DWPC matrix
     """
     category = categorize(metapath)
-    dwpc_function = _category_to_function(category, dwwc_method=dwwc_method, use_general=use_general)
+    dwpc_function = _category_to_function(category, dwwc_method=dwwc_method, approx_ok=approx_ok)
     row_names, col_names, dwpc_matrix = dwpc_function(
         graph, metapath, damping, dense_threshold=dense_threshold,
         dtype=dtype)

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -584,7 +584,7 @@ def _dwpc_approx(graph, metapath, damping=0.5, dense_threshold=0,
     first_repeat = repeated_nodes[0]
     repeated_indices = [i for i, v in enumerate(nodes) if v == first_repeat]
     for i, segment in enumerate(repeated_indices[1:]):
-        rows, cols, dwpc_matrix = dwwc(graph, metapath[repeated_indices[i]:segment],
+        rows, cols, dwpc_matrix = dwpc(graph, metapath[repeated_indices[i]:segment],
                                        damping=damping, dense_threshold=dense_threshold,
                                        dtype=dtype)
         if row_names is None:

--- a/hetmech/degree_weight.py
+++ b/hetmech/degree_weight.py
@@ -27,12 +27,12 @@ def _category_to_function(category, dwwc_method):
         'disjoint_groups': _dwpc_disjoint,
         'short_repeat': _dwpc_short_repeat,
         'four_repeat': _dwpc_baba,
-        'long_repeat': _dwpc_approx,
+        'long_repeat': _dwpc_general_case,
         'BAAB': _dwpc_baab,
         'BABA': _dwpc_baba,
         'repeat_around': _dwpc_repeat_around,
         'interior_complete_group': _dwpc_baba,
-        'other': _dwpc_approx,
+        'other': _dwpc_general_case,
     }
     return function_dictionary[category]
 

--- a/hetmech/tests/test_degree_weight.py
+++ b/hetmech/tests/test_degree_weight.py
@@ -641,7 +641,7 @@ def test_dtype(metapath, dtype, dwwc_method):
 @pytest.mark.parametrize('metapath,relative', [
     ('DrDaGiG', 'equal'),
     ('DaGiGaD', 'equal'),
-    ('DaGaDaGaD', 'not_equal'),
+    ('DaGaDrDaGaD', 'not_equal'),
     ('CrCpDrD', 'equal')
 ])
 def test_dwpc_approx(metapath, relative):
@@ -657,5 +657,5 @@ def test_dwpc_approx(metapath, relative):
     if relative == 'equal':
         assert abs((dwpc_approx - dwpc_matrix)).max() == pytest.approx(0, abs=1e-7)
     else:
-        assert sum(dwpc_approx - dwpc_matrix) >= 0
+        assert numpy.sum((dwpc_approx - dwpc_matrix)) >= 0
     assert abs((dwwc_matrix - dwpc_approx)).max() >= 0

--- a/hetmech/tests/test_degree_weight.py
+++ b/hetmech/tests/test_degree_weight.py
@@ -4,6 +4,7 @@ import pytest
 from scipy import sparse
 
 from hetmech.degree_weight import (
+    _dwpc_approx,
     _dwpc_baab,
     _dwpc_baba,
     _dwpc_general_case,
@@ -542,7 +543,6 @@ def test_get_segments(metapath, solution):
                  [0, 0.125, 0, 0.125, 0, 0, 0.125],
                  [0, 0, 0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0.125, 0, 0]]),
-    ('GiGiGiGiG', None),
     ('GaDaGaD', [[0.08838835, 0],  # BABA
                  [0.08838835, 0],
                  [0, 0.125],
@@ -636,3 +636,26 @@ def test_dtype(metapath, dtype, dwwc_method):
     metapath = graph.metagraph.metapath_from_abbrev(metapath)
     rows, cols, dwpc_matrix = dwpc(graph, metapath, dtype=dtype, dwwc_method=dwwc_method)
     assert dwpc_matrix.dtype == dtype
+
+
+@pytest.mark.parametrize('metapath,relative', [
+    ('DrDaGiG', 'equal'),
+    ('DaGiGaD', 'equal'),
+    ('DaGaDaGaD', 'not_equal'),
+    ('CrCpDrD', 'equal')
+])
+def test_dwpc_approx(metapath, relative):
+    url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
+        '30c6dbb18a17c05d71cb909cf57af7372e4d4908',
+        'test/data/random-subgraph.json.xz',
+    )
+    graph = hetio.readwrite.read_graph(url)
+    metapath = graph.metagraph.metapath_from_abbrev(metapath)
+    rows, cols, dwpc_matrix = dwpc(graph, metapath)
+    rows, cols, dwpc_approx = _dwpc_approx(graph, metapath)
+    rows, cols, dwwc_matrix = dwwc(graph, metapath)
+    if relative == 'equal':
+        assert abs((dwpc_approx - dwpc_matrix)).max() == pytest.approx(0, abs=1e-7)
+    else:
+        assert sum(dwpc_approx - dwpc_matrix) >= 0
+    assert abs((dwwc_matrix - dwpc_approx)).max() >= 0


### PR DESCRIPTION
My approximation method is basically the following:

1. Find the first repeated metanode.
2. Compute DWPC in the segment between each occurrence of this metanode, removing the diagonal afterwards.
3. Compute DWPC for the head and tail segments if they are present.

For example:

Given CbGiGaDrDaGpBP
1. G, [1,2,5]
2. `remove_diag(GiG @ dwpc(GaDrDaG))`
3. CbG @ GiGaDrDaG @ GpBP

I have changed so that under `use_general=False`, rather than returning an error, we simply output an approximate.