### PR TITLE
Pipeline: use grouped writer for adjusted-DWPCs

### DIFF
--- a/explore/bulk-pipeline/bulk.ipynb
+++ b/explore/bulk-pipeline/bulk.ipynb
@@ -13,6 +13,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import itertools\n",
+    "\n",
     "import numpy\n",
     "import pandas\n",
     "import pathlib\n",
@@ -251,6 +253,38 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def grouper(iterable, group_size):\n",
+    "    \"\"\"\n",
+    "    Group an iterable into chunks of group_size.\n",
+    "    Derived from https://stackoverflow.com/a/8998040/4651668\n",
+    "    \"\"\"\n",
+    "    iterable = iter(iterable)\n",
+    "    while True:\n",
+    "        chunk = itertools.islice(iterable, group_size)\n",
+    "        try:\n",
+    "            head = next(chunk),\n",
+    "        except StopIteration:\n",
+    "            break\n",
+    "        yield itertools.chain(head, chunk)\n",
+    "\n",
+    "def grouped_tsv_writer(row_generator, path, group_size=20_000, sep='\\t', index=False, **kwargs):\n",
+    "    \"\"\"\n",
+    "    Write an iterable of dictionaries to a TSV, where each dictionary is a row.\n",
+    "    \"\"\"\n",
+    "    chunks = grouper(row_generator, group_size=group_size)\n",
+    "    for i, chunk in enumerate(chunks):\n",
+    "        df = pandas.DataFrame.from_records(chunk)\n",
+    "        kwargs['header'] = not bool(i)\n",
+    "        kwargs['mode'] = 'a' if i else 'w'\n",
+    "        df.to_csv(path, sep=sep, index=index, **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [
@@ -258,18 +292,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 50%|█████     | 1/2 [00:00<00:00,  1.11it/s]"
+      " 50%|█████     | 1/2 [00:00<00:00,  1.31it/s]"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "for metapath in tqdm.tqdm(metapaths):\n",
-    "    dwpcs_rows = hetmech.pipeline.combine_dwpc_dgp(hetmat, metapath, damping=0.5, ignore_zeros=True, max_p_value=0.1)\n",
-    "    dwpc_df = pandas.DataFrame(dwpcs_rows).sort_values(['source_id', 'target_id'])\n",
+    "    dwpcs_rows = hetmech.pipeline.combine_dwpc_dgp(hetmat, metapath, damping=0.5, ignore_zeros=True, max_p_value=0.05)\n",
     "    path = hetmat.directory.joinpath('adjusted-path-counts', 'dwpc-0.5',\n",
     "                                     'adjusted-dwpcs', f'{metapath}-filtered.tsv.gz')\n",
-    "    dwpc_df.to_csv(path, sep='\\t', index=False, compression='gzip', float_format='%.7g')"
+    "    grouped_tsv_writer(dwpcs_rows, path, float_format='%.7g', compression='gzip')"
    ]
   }
  ],

--- a/explore/bulk-pipeline/bulk.ipynb
+++ b/explore/bulk-pipeline/bulk.ipynb
@@ -13,8 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import itertools\n",
-    "\n",
     "import numpy\n",
     "import pandas\n",
     "import pathlib\n",
@@ -100,7 +98,6 @@
     }
    ],
    "source": [
-    "%%time\n",
     "hetmat.path_counts_cache = hetmech.hetmat.caching.PathCountPriorityCache(hetmat, allocate_GB=16)\n",
     "for metapath in tqdm.tqdm(metapaths):\n",
     "    row_ids, col_ids, pc_matrix = hetmech.degree_weight.dwpc(hetmat, metapath, damping=0, dense_threshold=0.7, dtype='uint64')\n",
@@ -167,7 +164,6 @@
     }
    ],
    "source": [
-    "%%time\n",
     "hetmat.path_counts_cache = hetmech.hetmat.caching.PathCountPriorityCache(hetmat, allocate_GB=16)\n",
     "mean_dwpcs = dict()\n",
     "for metapath in tqdm.tqdm(metapaths):\n",
@@ -253,38 +249,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def grouper(iterable, group_size):\n",
-    "    \"\"\"\n",
-    "    Group an iterable into chunks of group_size.\n",
-    "    Derived from https://stackoverflow.com/a/8998040/4651668\n",
-    "    \"\"\"\n",
-    "    iterable = iter(iterable)\n",
-    "    while True:\n",
-    "        chunk = itertools.islice(iterable, group_size)\n",
-    "        try:\n",
-    "            head = next(chunk),\n",
-    "        except StopIteration:\n",
-    "            break\n",
-    "        yield itertools.chain(head, chunk)\n",
-    "\n",
-    "def grouped_tsv_writer(row_generator, path, group_size=20_000, sep='\\t', index=False, **kwargs):\n",
-    "    \"\"\"\n",
-    "    Write an iterable of dictionaries to a TSV, where each dictionary is a row.\n",
-    "    \"\"\"\n",
-    "    chunks = grouper(row_generator, group_size=group_size)\n",
-    "    for i, chunk in enumerate(chunks):\n",
-    "        df = pandas.DataFrame.from_records(chunk)\n",
-    "        kwargs['header'] = not bool(i)\n",
-    "        kwargs['mode'] = 'a' if i else 'w'\n",
-    "        df.to_csv(path, sep=sep, index=index, **kwargs)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
    "outputs": [
@@ -312,12 +276,11 @@
     }
    ],
    "source": [
-    "%%time\n",
     "for metapath in tqdm.tqdm(metapaths):\n",
     "    dwpcs_rows = hetmech.pipeline.combine_dwpc_dgp(hetmat, metapath, damping=0.5, ignore_zeros=True, max_p_value=0.05)\n",
     "    path = hetmat.directory.joinpath('adjusted-path-counts', 'dwpc-0.5',\n",
     "                                     'adjusted-dwpcs', f'{metapath}-filtered.tsv.gz')\n",
-    "    grouped_tsv_writer(dwpcs_rows, path, float_format='%.7g', compression='gzip')"
+    "    hetmech.pipeline.grouped_tsv_writer(dwpcs_rows, path, float_format='%.7g', compression='gzip')"
    ]
   }
  ],

--- a/explore/bulk-pipeline/bulk.ipynb
+++ b/explore/bulk-pipeline/bulk.ipynb
@@ -285,14 +285,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 50%|█████     | 1/2 [00:00<00:00,  1.31it/s]"
+      "100%|██████████| 2/2 [42:24<00:00, 1272.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 42min 7s, sys: 16.9 s, total: 42min 24s\n",
+      "Wall time: 42min 24s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],

--- a/hetmech/tests/test_pipeline.py
+++ b/hetmech/tests/test_pipeline.py
@@ -1,0 +1,48 @@
+from hetmech.pipeline import (
+    grouper,
+)
+
+
+def test_grouper_equal_chunks():
+    iterable = range(10)
+    grouped = grouper(iterable, group_size=2)
+    grouped = list(map(tuple, grouped))
+    assert grouped == [
+        (0, 1),
+        (2, 3),
+        (4, 5),
+        (6, 7),
+        (8, 9),
+    ]
+
+
+def test_grouper_ragged_chunks():
+    iterable = range(7)
+    grouped = grouper(iterable, group_size=3)
+    grouped = list(map(tuple, grouped))
+    assert grouped == [
+        (0, 1, 2),
+        (3, 4, 5),
+        (6,),
+    ]
+
+
+def test_grouper_one_group():
+    iterable = range(7)
+    grouped = grouper(iterable, group_size=20)
+    grouped = list(map(tuple, grouped))
+    assert grouped == [
+        (0, 1, 2, 3, 4, 5, 6),
+    ]
+
+
+def test_grouper_length_1():
+    iterable = range(4)
+    grouped = grouper(iterable, group_size=1)
+    grouped = list(map(tuple, grouped))
+    assert grouped == [
+        (0,),
+        (1,),
+        (2,),
+        (3,),
+    ]


### PR DESCRIPTION
Enables using pandas.to_csv on generators of rows that are too big for memory.