### PR TITLE
add find_packages()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup
+from setuptools import find_packages
 
 setup(name='hetmech',
       description='A search engine for hetnets',
       long_description='Matrix implementations of path-count-based measures',
       url='https://github.com/greenelab/hetmech',
       license='BSD 3-Clause License',
-      packages=['hetmech'],
+      packages=find_packages(),
       install_requires=[
           'hetio>=0.2.8',
           'numpy',


### PR DESCRIPTION
refs https://github.com/greenelab/hetmech/issues/145#issuecomment-434412918

This enables the conda environment to see the `hetmat` folder during install