### PR TITLE
Add CircaDB dataset

### DIFF
--- a/explore/circadian-efficacy/README.md
+++ b/explore/circadian-efficacy/README.md
@@ -7,5 +7,6 @@ Evaluating unsupervised DWPC p-values and path contributions to predict whether 
 
 + [`downloads/HumCircMed2018v2.xlsx`](downloads/HumCircMed2018v2.xlsx) contains the data to generate Figure S1 from [version 1 of the "Dosing Time Matters" preprint](https://www.biorxiv.org/content/10.1101/570119v1.full).
 
-['downloads/aat8806_Data_file_S1.xlsx'](downloads/aat8806_Data_file_S1.xlsx) contains data from CircaDB, which provides tissue-specific rhythmical scores for human genes. The data was downloaded from Data file S1 of [A database of tissue-specific rhythmically expressed human genes has potential applications in circadian medicine](http://stm.sciencemag.org/content/10/458/eaat8806). The algorithm 'CYCLOPS', which was developed to score genes based on circadian rhythms, can be accessed from [CYCLOPS reveals human transcriptional rhythms in
-health and disease](https://www.pnas.org/content/114/20/5312.long)
++ [`downloads/aat8806_Data_file_S1.xlsx`](downloads/aat8806_Data_file_S1.xlsx) contains data from CircaDB, which provides tissue-specific rhythmical scores for human genes. 
+  The data was downloaded from Data file S1 of [A database of tissue-specific rhythmically expressed human genes has potential applications in circadian medicine](https://doi.org/10.1126/scitranslmed.aat8806).
+  The algorithm 'CYCLOPS', which was developed to score genes based on circadian rhythms, can be accessed from [CYCLOPS reveals human transcriptional rhythms in health and disease](https://doi.org/10.1073/pnas.1619320114).

--- a/explore/circadian-efficacy/README.md
+++ b/explore/circadian-efficacy/README.md
@@ -6,3 +6,6 @@ Evaluating unsupervised DWPC p-values and path contributions to predict whether 
 # Source datasets
 
 + [`downloads/HumCircMed2018v2.xlsx`](downloads/HumCircMed2018v2.xlsx) contains the data to generate Figure S1 from [version 1 of the "Dosing Time Matters" preprint](https://www.biorxiv.org/content/10.1101/570119v1.full).
+
+['downloads/aat8806_Data_file_S1.xlsx'](downloads/aat8806_Data_file_S1.xlsx) contains data from CircaDB, which provides tissue-specific rhythmical scores for human genes. The data was downloaded from Data file S1 of [A database of tissue-specific rhythmically expressed human genes has potential applications in circadian medicine](http://stm.sciencemag.org/content/10/458/eaat8806). The algorithm 'CYCLOPS', which was developed to score genes based on circadian rhythms, can be accessed from [CYCLOPS reveals human transcriptional rhythms in
+health and disease](https://www.pnas.org/content/114/20/5312.long)


### PR DESCRIPTION
The dataset provides tissue-specific circadian scores for human genes. Detailed information can be found in README.